### PR TITLE
Remove global variable usage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,5 +19,5 @@ Metrics/BlockLength:
   Exclude:
     - '*.rake'
 
-Style/GlobalVars:
+Style/FetchEnvVar:
   Enabled: false

--- a/changelog.rake
+++ b/changelog.rake
@@ -12,7 +12,7 @@ namespace :changelog do
       warn('The first line of changelog must match "Unreleased Changes"')
       exit(1)
     end
-    changelog[0] = "#{$VERSION} (#{Time.now.strftime('%Y-%m-%d')})\n"
+    changelog[0] = "#{ENV['VERSION']} (#{Time.now.strftime('%Y-%m-%d')})\n"
     changelog = changelog.join
     File.open('CHANGELOG.md', 'w', encoding: 'UTF-8') { |f| f.write(changelog) }
     sh('git add CHANGELOG.md')

--- a/gems.rake
+++ b/gems.rake
@@ -14,7 +14,7 @@ namespace :gems do
   desc 'Push (release) the gem to RubyGems'
   idempotent_task :push do
     puts 'TASK START: gems:push'
-    sh("gem push #{gem_name}-#{$VERSION}.gem")
+    sh("gem push #{gem_name}-#{ENV['VERSION']}.gem")
     puts 'TASK END: gems:push'
   end
 

--- a/git.rake
+++ b/git.rake
@@ -49,11 +49,11 @@ namespace :git do
   desc 'Add a tag of the version release'
   task :tag do
     puts 'TASK START: git:tag'
-    sh("git commit -m \"Bumped version to v#{$VERSION}\"")
+    sh("git commit -m \"Bumped version to v#{ENV['VERSION']}\"")
     # Don't use interpolation here: changelog entries often have
     # backticks for formatting, and those will get run as commands
     # here otherwise.
-    sh("git tag -a -m \"#{tag_message.gsub('`', '\\\`')}\" v#{$VERSION}")
+    sh("git tag -a -m \"#{tag_message.gsub('`', '\\\`')}\" v#{ENV['VERSION']}")
     puts 'TASK END: git:tag'
   end
 

--- a/github.rake
+++ b/github.rake
@@ -19,28 +19,24 @@ namespace :github do
     puts 'TASK START: github:release'
     require 'octokit'
 
-    gh = Octokit::Client.new(access_token: ENV.fetch(
-      'AWS_SDK_FOR_RUBY_GH_TOKEN', nil
-    ))
-
+    gh = Octokit::Client.new(access_token: ENV['AWS_SDK_FOR_RUBY_GH_TOKEN'])
     repo = `git remote get-url origin`
            .sub('ssh://', '')
            .sub('git@github.com:', '')
            .sub(".git\n", '').chomp
-    tag_ref_sha = `git show-ref v#{$VERSION}`.split.first
+    tag_ref_sha = `git show-ref v#{ENV['VERSION']}`.split.first
     tag = gh.tag(repo, tag_ref_sha)
-
-    name = "Release v#{$VERSION} - #{tag.tagger.date.strftime('%Y-%m-%d')}"
+    date = tag.tagger.date.strftime('%Y-%m-%d')
     release = gh.create_release(
-      repo, "v#{$VERSION}",
-      name: name,
+      repo, "v#{ENV['VERSION']}",
+      name: "Release v#{ENV['VERSION']} - #{date}",
       body: tag.message,
-      prerelease: $VERSION.match('rc') ? true : false
+      prerelease: ENV['VERSION'].match('rc') ? true : false
     )
 
     gh.upload_asset(
       release.url,
-      "#{gem_name}-#{$VERSION}.gem",
+      "#{gem_name}-#{ENV['VERSION']}.gem",
       content_type: 'application/octet-stream'
     )
     puts 'TASK END: github:release'

--- a/release.rake
+++ b/release.rake
@@ -45,7 +45,7 @@ namespace :release do
   desc 'bumps the VERSION file'
   idempotent_task :bump_version do
     puts 'TASK START: release:bump_version'
-    sh("echo '#{$VERSION}' > VERSION")
+    sh("echo '#{ENV['VERSION']}' > VERSION")
     sh('git add VERSION')
     puts 'TASK END: release:bump_version'
   end

--- a/release_utils.rb
+++ b/release_utils.rb
@@ -28,7 +28,7 @@ def tag_message
   issues = `git log $(git describe --tags --abbrev=0)...HEAD -E \
               --grep '#[0-9]+' 2>/dev/null`
   issues = issues.scan(%r{((?:\S+/\S+)?#\d+)}).flatten
-  msg = String.new("Tag release v#{ENV.fetch('VERSION', nil)}")
+  msg = String.new("Tag release v#{ENV['VERSION']}")
   msg << "\n\n"
   unless issues.empty?
     msg << "References: #{issues.uniq.sort.join(', ')}"


### PR DESCRIPTION
Remove global variable usage so it doesn't need to be defined in 1p gem Rakefiles. We validate `ENV['VERSION']` is used on release, and each repo has `$VERSION = ENV['VERSION'] || File.read(File.join($REPO_ROOT, 'VERSION')).strip` but `$VERSION` is not used anywhere in the 1P gems.